### PR TITLE
Fix path to JobBase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is recommended that you install the Gearman library [through composer](http:/
 ```php
 namespace common\jobs;
 
-use micmorozov\yii2-gearman\JobBase;
+use micmorozov\yii2\gearman\JobBase;
 
 class SyncCalendar extends JobBase
 {


### PR DESCRIPTION
Previous path was causing PHP errors due to the hyphen.